### PR TITLE
respect origin setting in vite server config for entrypoints

### DIFF
--- a/src/configResolver.ts
+++ b/src/configResolver.ts
@@ -5,8 +5,11 @@ import type { ResolvedConfig } from "vite";
 const getDevEntryPoints = (config: ResolvedConfig) => {
   const entryPoints: EntryPoints = {};
 
-  const { host = "localhost", port = 3000, https = false } = config.server;
-  const origin = `http${https ? "s" : ""}://${host}:${port}`;
+  let { host = "localhost", port = 3000, https = false, origin = undefined } = config.server;
+  
+  if (origin === undefined || origin === "") {
+    origin = `http${https ? "s" : ""}://${host}:${port}`;
+  }
 
   for (const [entryName, entryPath] of Object.entries(parseInput(config))) {
     entryPoints[entryName] = {


### PR DESCRIPTION
Hello there,

thanks for creating the vite-bundle + plugin.

I need to set this https://vitejs.dev/config/#server-origin for my setup within docker. Unfortunately the symfony plugin is using the host +  port combination instead of using the origin

