### PR TITLE
feat: add recursive option to rmSync to remove directories

### DIFF
--- a/src/fileHelper.ts
+++ b/src/fileHelper.ts
@@ -13,7 +13,7 @@ const writeJson = (filePath: string, jsonData: EntryPointsFile) => {
 const emptyDir = (dir: string) => {
   const files = readdirSync(dir);
   for (const file of files) {
-    rmSync(join(dir, file), {});
+    rmSync(join(dir, file), { recursive: true });
   }
 };
 


### PR DESCRIPTION
When running `vite dev` after `vite build` I got the following error message:

```
error when starting dev server:
SystemError [ERR_FS_EISDIR]: Path is a directory: rm returned EISDIR (is a directory) <path-to-project>/public/build/bundles
    at rmSync (fs.js:935:13)
    at emptyDir (<path-to-project>/node_modules/vite-plugin-symfony/dist/fileHelper.js:18:25)
    at Object.configResolved (<path-to-project>/node_modules/vite-plugin-symfony/dist/index.js:41:77)
    at <path-to-project>/node_modules/vite/dist/node/chunks/dep-9c153816.js:71056:127
    at Array.map (<anonymous>)
    at resolveConfig (<path-to-project>/node_modules/vite/dist/node/chunks/dep-9c153816.js:71056:35)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async createServer (<path-to-project>/node_modules/vite/dist/node/chunks/dep-9c153816.js:56425:20)
    at async CAC.<anonymous> (<path-to-project>/node_modules/vite/dist/node/cli.js:688:24)
```

The bundles directory could not be removed. This PR adds the recursive option to the rmSync call.