### PR TITLE
add originOverride option to reconcile dev assets origin with proxy s…

### DIFF
--- a/src/pluginOptions.ts
+++ b/src/pluginOptions.ts
@@ -30,6 +30,7 @@ export function resolvePluginOptions(userConfig: Partial<VitePluginSymfonyOption
   }
 
   return {
+    originOverride: userConfig.originOverride ?? null,
     buildDirectory: userConfig.buildDirectory,
     publicDirectory: userConfig.publicDirectory,
     refresh: userConfig.refresh ?? false,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -171,4 +171,11 @@ export type VitePluginSymfonyOptions = {
    * @default false
    */
   debug: boolean;
+
+  /**
+   * Override the origin for every dev entrypoint.
+   * Useful when you use a proxy server.
+   * @default null
+   */
+  originOverride: null | string;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,10 @@ export function resolveDevServerUrl(
   config: ResolvedConfig,
   pluginOptions: VitePluginSymfonyOptions,
 ): DevServerUrl {
+  if (pluginOptions.originOverride) {
+    return pluginOptions.originOverride as DevServerUrl;
+  }
+
   if (config.server?.origin) {
     return config.server.origin as DevServerUrl;
   }


### PR DESCRIPTION
I have my Vite dev server behind a proxy, with a different protocol, hostname and port than the original server. In order to get dev assets loaded from the browser, I need to change their origin in entrypoints.json.