### PR TITLE
Fix TypeError when handling Vite user config with no root option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export default function symfony(userOptions: Partial<VitePluginSymfonyOptions> =
     name: "symfony",
     enforce: "post",
     config(userConfig) {
-      const root = resolve(userConfig.root) ?? cwd();
+      const root = userConfig.root ? resolve(userConfig.root) : cwd();
 
       if (userConfig.build.rollupOptions.input instanceof Array) {
         console.error("rollupOptions.input must be an Objet like {app: './assets/app.js'}");

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -17,6 +17,7 @@ import {
   logoPng,
   circular1Js,
   circular2Js,
+  viteUserConfigNoRoot,
 } from "./mocks";
 
 function createBundleObject(files: (OutputChunk | OutputAsset)[]) {
@@ -397,6 +398,28 @@ describe("vitePluginSymfony", () => {
         2,
       ),
       type: "asset",
+    });
+  });
+
+  it("loads correctly without root user config option", ({ expect }) => {
+    const pluginInstance = vitePluginSymfony({ debug: true }) as any;
+    const config = pluginInstance.config(viteUserConfigNoRoot);
+
+    expect(config).toEqual({
+      base: "/build/",
+      publicDir: false,
+      build: {
+        manifest: true,
+        outDir: "public/build",
+      },
+      optimizeDeps: {
+        force: true,
+      },
+      server: {
+        watch: {
+          ignored: ["**/vendor/**", process.cwd() + "/var/**", process.cwd() + "/public/**"],
+        },
+      },
     });
   });
 });

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -1,5 +1,5 @@
 import type { OutputChunk, OutputAsset } from "rollup";
-import type { ResolvedConfig } from "vite";
+import type { ResolvedConfig, UserConfig } from "vite";
 import { ChunkMetadata } from "../types";
 
 export const viteBaseConfig = {
@@ -7,6 +7,14 @@ export const viteBaseConfig = {
   base: "/build/",
   plugins: [{ name: "symfony" }, { name: "vite:reporter" }],
 } as unknown as ResolvedConfig;
+
+export const viteUserConfigNoRoot = {
+  base: "/build/",
+  plugins: [{ name: "symfony" }, { name: "vite:reporter" }],
+  build: {
+    rollupOptions: {},
+  },
+} as unknown as UserConfig;
 
 export const pageImports = {
   dynamicImports: ["assets/async-dep-e2ac9f96.js"],


### PR DESCRIPTION
The `root` option in Vite's user config is optional however the change made in https://github.com/lhapaipai/vite-plugin-symfony/commit/b6bdc633d32bcd45a31878db4a8695f356067652 assumes it will always be set.

When it is not set this plugin is crashing the dev server and throwing the following TypeError:

```console
error when starting dev server:
TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at resolve (node:path:1097:7)
    at config (/app/node_modules/vite-plugin-symfony/dist/index.js:5996:50)
    at runConfigHook (file:///app/node_modules/vite/dist/node/chunks/dep-2b82a1ce.js:66346:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async resolveConfig (file:///app/node_modules/vite/dist/node/chunks/dep-2b82a1ce.js:65787:14)
    at async _createServer (file:///app/node_modules/vite/dist/node/chunks/dep-2b82a1ce.js:65031:20)
    at async CAC.<anonymous> (file:///app/node_modules/vite/dist/node/cli.js:763:24)
```

This PR fixes the issue by checking whether userConfig.root is set before resolving it, falling back to cwd() otherwise.

I've also added a test in a separate commit which fails without my fix and succeeds with it.