### PR TITLE
fixed symfony/ux-react inability to load tsx components

### DIFF
--- a/src/stimulus/helpers/react/index.ts
+++ b/src/stimulus/helpers/react/index.ts
@@ -9,7 +9,7 @@ export function registerReactControllerComponents(
   reactImportedModules = { ...reactImportedModules, ...modules };
 
   window.resolveReactComponent = (name: string): ImportedModule<ReactModule> => {
-    const reactModule = reactImportedModules[`${controllersDir}/${name}.jsx` || `${controllersDir}/${name}.tsx`];
+    const reactModule = reactImportedModules[`${controllersDir}/${name}.jsx`] || reactImportedModules[`${controllersDir}/${name}.tsx`];
     if (typeof reactModule === "undefined") {
       const possibleValues = Object.keys(reactImportedModules).map((key) =>
         key.replace(`${controllersDir}/`, "").replace(".jsx", "").replace(".tsx", ""),


### PR DESCRIPTION
I've noticed that due to a logic error it's not possible to use tsx components